### PR TITLE
Fix AnkiWeb bug

### DIFF
--- a/front.html
+++ b/front.html
@@ -26,7 +26,11 @@
       var divOriginal = document.getElementById("cloze-original");
       var divJsRendered = document.getElementById("cloze-js-rendered");
 
-      var currentCloze = +(document.body.className.match(/(^|\s)card(\d+)(\s|$)/)[2] || 0);
+      var currentCloze = +(
+          (document.body.className.match(/(^|\s)card(\d+)(\s|$)/) || [])[2] ||
+          ((document.getElementById("qa_box") && document.getElementById("qa_box").className && document.getElementById("qa_box").className.match(/(^|\s)card(\d+)(\s|$)/)) || [])[2] ||
+          0
+      );
 
       var allClozes = (function(){
         var allMatches = divOriginal.innerHTML.match(/\{\{c\d+::[\s\S]*?\}\}/g);


### PR DESCRIPTION
I made some changes to the current code to fix an error that occurs when a card made with this template is used on the AnkiWeb interface. On AnkiWeb, the card number is displayed in the `#qa_box` element's className (this element only exists on AnkiWeb AFAIK) instead of the body's className. This causes a TypeError when the code tries to access the null return of the `document.body.className.match()`, and the result is that the actual card number is not retrieved. 

To resolve this issue, I added an extra check to the problematic line of code. Please feel free to format the code however you prefer, including splitting it up into multiple lines. You can check out the changes in this pull request. Thanks for making this template by the way!