### PR TITLE
Add `numHiddenClozes` to suggest there’s more on the _middle_ cards

### DIFF
--- a/front.html
+++ b/front.html
@@ -60,7 +60,7 @@
             replacement = isBackSide ? allClozes[i].clozes[orig].content : "[" + allClozes[i].clozes[orig].placeholder + "]";
           } else if (currentCloze - leadingClozes <= i && i <= currentCloze + followingClozes + (clozesPerCard - 1))
             replacement = allClozes[i].clozes[orig].content;
-          else if (currentCloze - numHiddenClozes - 1 <= i && i <= currentCloze + numHiddenClozes + clozesPerCard && !allClozes[i].askAll)
+          else if (currentCloze - numHiddenClozes - leadingClozes <= i && i <= currentCloze + numHiddenClozes + clozesPerCard + followingClozes - 1 && !allClozes[i].askAll)
             replacement = (isBackSide && revealAllClozes) ? allClozes[i].clozes[orig].content : "[" + (revealAllCustomPlaceholders ? allClozes[i].clozes[orig].placeholder : "...") + "]";
           else {
             replacement = "";

--- a/front.html
+++ b/front.html
@@ -18,7 +18,7 @@
       var config = document.getElementById("cloze-overlapping-config").innerText.split(/[,\s|.]+/);
       var leadingClozes = config[0] === "0" ? 0 : (+config[0] || 1);
       var followingClozes = +config[1] || 0;
-      var showAllClozes = (config[2] || "true").toLowerCase() === "true"; // Set to false to omit, e.g. for long lyrics/poems
+      var numHiddenClozes = config[2].toLowerCase() === "true" ? 9999999 : (+config[2] || 0); // Set to false or 0 to omit, e.g. for long lyrics/poems; set to 1 to suggest there’s more on the middle cards.
       var revealAllClozes = (config[3] || "false").toLowerCase() === "true"; // On the back, reveal other clozes we didnʼt ask for?
       var revealAllCustomPlaceholders = (config[4] || "false").toLowerCase() === "true";
       var clozesPerCard = +config[5] || 1; // How many clozes to ask for each time? Wozniak suggests 3 for alphabet.
@@ -60,7 +60,7 @@
             replacement = isBackSide ? allClozes[i].clozes[orig].content : "[" + allClozes[i].clozes[orig].placeholder + "]";
           } else if (currentCloze - leadingClozes <= i && i <= currentCloze + followingClozes + (clozesPerCard - 1))
             replacement = allClozes[i].clozes[orig].content;
-          else if (showAllClozes && !allClozes[i].askAll)
+          else if (currentCloze - numHiddenClozes - 1 <= i && i <= currentCloze + numHiddenClozes + clozesPerCard && !allClozes[i].askAll)
             replacement = (isBackSide && revealAllClozes) ? allClozes[i].clozes[orig].content : "[" + (revealAllCustomPlaceholders ? allClozes[i].clozes[orig].placeholder : "...") + "]";
           else {
             replacement = "";


### PR DESCRIPTION
In the alphabet example, instead of:

```
B
[…]
[…]
[…]
F
```

… you can now have:

```
[…]
B
[…]
[…]
[…]
F
[…]
```

… if you set the third parameter to `1`. It stays backwards compatible with the older version, and interprets `true` as infinity, and `false` (anything not parsable as a number) as zero (the same behavior).

![image](https://github.com/user-attachments/assets/9d1c993a-0a99-4d52-8b2b-aef92622c19f)
